### PR TITLE
`fail!` macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+script:
+  - cargo -V
+  - rustc -V
+  - RUST_BACKTRACE=1 cargo build --verbose --all
+  - RUST_BACKTRACE=1 cargo test --verbose --all
+notifications:
+  on_success: never
+  on_failure: always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@
 pub mod arithmetic;
 #[macro_use]
 pub mod string;
+#[macro_use]
+pub mod unit_test_utils;

--- a/src/unit_test_utils/mod.rs
+++ b/src/unit_test_utils/mod.rs
@@ -1,0 +1,18 @@
+/*!
+This module is dedicated to unit test tools. There are some basic macros to generate your unit tests functions and mark them as "unimplemented" with
+intelligible error messages.
+*/
+
+/// Panics the unit test and prints an error message.
+/// ```rust,ignore
+/// # #[macro_use]
+/// # extern crate rustutils;
+/// let foo = "fail_panicked_test_1";
+/// fail!(&foo); // prints: The 'fail_panicked_test_1' unit test has not been implemented yet.
+/// ```
+#[macro_export]
+macro_rules! fail {
+    ($unit_test_name:expr) => (
+        panic!("The '{}' unit test has not been implemented yet.", &$unit_test_name)
+    );
+}

--- a/tests/fail_macro.rs
+++ b/tests/fail_macro.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate rustutils;
+
+
+#[test]
+#[should_panic(expected = "The 'fail_panicked_test_1' unit test has not been implemented yet.")]
+fn fail_panicked_test_1() {
+    let foo = "fail_panicked_test_1";
+    fail!(&foo);
+}


### PR DESCRIPTION
The `fail!` macro allows you to customize your "unimplemented feature" error message.